### PR TITLE
APP-5983 iOS - Images: Undo after multiple edits of an image lead to app crash

### DIFF
--- a/Sources/iOSPhotoEditor/PhotoEditor+Controls.swift
+++ b/Sources/iOSPhotoEditor/PhotoEditor+Controls.swift
@@ -156,6 +156,8 @@ extension PhotoEditorViewController {
     }
     
     @IBAction func continueButtonPressed(_ sender: Any) {
+        clearUndoManager()
+        
         let img = self.canvasView.toImage()
         photoEditorDelegate?.doneEditing(image: img)
         self.dismiss(animated: true, completion: nil)
@@ -232,12 +234,18 @@ extension PhotoEditorViewController {
         UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
     }
     
+    private func clearUndoManager() {
+        undoManager?.removeAllActions(withTarget: self)
+    }
+    
     func manageBarButtonVisibility() {
         undoButton.isEnabled = undoManager?.canUndo ?? false
         redoButton.isEnabled = undoManager?.canRedo ?? false
     }
     
     func cancel() {
+        clearUndoManager()
+        
         photoEditorDelegate?.canceledEditing()
         dismiss(animated: true, completion: nil)
         

--- a/Sources/iOSPhotoEditor/PhotoEditor+Drawing.swift
+++ b/Sources/iOSPhotoEditor/PhotoEditor+Drawing.swift
@@ -10,13 +10,14 @@ import UIKit
 extension PhotoEditorViewController {
     
     override public func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?){
-        coloredLines.append([ColoredPoint]())
-        
         if isDrawing {
             swiped = false
             if let touch = touches.first {
                 lastPoint = touch.location(in: self.canvasImageView)
             }
+            
+            let firstColoredLine = [ColoredPoint(point: lastPoint, color: drawColor)]
+            coloredLines.append(firstColoredLine)
         }
             //Hide stickersVC if clicked outside it
         else if let stickersViewController = self.stickersViewController {
@@ -27,10 +28,6 @@ extension PhotoEditorViewController {
                 }
             }
         }
-        
-        guard var firstColoredLine = coloredLines.popLast() else { return }
-        firstColoredLine.append(ColoredPoint(point: lastPoint, color: drawColor))
-        coloredLines.append(firstColoredLine)
     }
     
     override public func touchesMoved(_ touches: Set<UITouch>,
@@ -55,12 +52,12 @@ extension PhotoEditorViewController {
     
     override public func touchesEnded(_ touches: Set<UITouch>,
                                       with event: UIEvent?){
-        if isDrawing {
-            if !swiped {
-                // draw a single point
-                draw { cgContext in
-                    drawLineFrom(lastPoint, toPoint: lastPoint, withColor: drawColor, cgContext: cgContext)
-                }
+        guard isDrawing else { return }
+        
+        if !swiped {
+            // draw a single point
+            draw { cgContext in
+                drawLineFrom(lastPoint, toPoint: lastPoint, withColor: drawColor, cgContext: cgContext)
             }
         }
         addLineUndoActionRegister()

--- a/Sources/iOSPhotoEditor/PhotoEditorViewController.swift
+++ b/Sources/iOSPhotoEditor/PhotoEditorViewController.swift
@@ -164,6 +164,11 @@ public final class PhotoEditorViewController: UIViewController {
         super.viewWillAppear(animated)
         showToolbar(show: true, animated: false)
     }
+    
+    public override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        undoManager?.removeAllActions()
+    }
 
     public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)

--- a/Sources/iOSPhotoEditor/PhotoEditorViewController.swift
+++ b/Sources/iOSPhotoEditor/PhotoEditorViewController.swift
@@ -164,11 +164,6 @@ public final class PhotoEditorViewController: UIViewController {
         super.viewWillAppear(animated)
         showToolbar(show: true, animated: false)
     }
-    
-    public override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        undoManager?.removeAllActions()
-    }
 
     public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)


### PR DESCRIPTION
### **Issue**

A crash occurred with `EXC_BAD_ACCESS` when invoking `undoManager?.undo()`. This was caused by the `UndoManager` retaining undo actions that referenced a deallocated view controller. When the undo action was triggered, it attempted to execute a method on the invalid reference, leading to a memory access violation.

### **Root Cause**

Undo actions were registered using the view controller (`self`) as the undo target. Since `UndoManager` is managed via the responder chain and can outlive the view controller, these retained actions became unsafe after the view controller was deallocated.

### **Solution**

All undo actions are now cleared in `viewWillDisappear(_:)` by calling `undoManager?.removeAllActions()`. This ensures that undo actions are safely discarded while the view controller is still in the responder chain and before it is deallocated, preventing the crash.
